### PR TITLE
Added -it flag for command-line input text

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Main Features
 -------------
 
 * Unsupervised approach
-* Multi-Language Support 
+* Multi-Language Support
 * Single document
 
 Rationale
@@ -54,24 +54,20 @@ Command line
 ************************
 How to use it on your favorite command line::
 
+		Usage: yake [OPTIONS]
 
-```shell
-Usage: yake [OPTIONS]
-
-Options:
-  -ti, --text_input TEXT          Input text, SURROUNDED by single quotes(')
-  -i, --input_file TEXT           Input file
-  -l, --language TEXT             Language
-  -n, --ngram-size INTEGER        Max size of the ngram.
-  -df, --dedup-func [leve|jaro|seqm]
-                                  Deduplication function.
-  -dl, --dedup-lim FLOAT          Deduplication limiar.
-  -ws, --window-size INTEGER      Window size.
-  -t, --top INTEGER               Number of keyphrases to extract
-  -v, --verbose
-  --help                          Show this message and exit.
-```
-
+		Options:
+		  -ti, --text_input TEXT          Input text, SURROUNDED by single quotes(')
+		  -i, --input_file TEXT           Input file
+		  -l, --language TEXT             Language
+		  -n, --ngram-size INTEGER        Max size of the ngram.
+		  -df, --dedup-func [leve|jaro|seqm]
+		                                  Deduplication function.
+		  -dl, --dedup-lim FLOAT          Deduplication limiar.
+		  -ws, --window-size INTEGER      Window size.
+		  -t, --top INTEGER               Number of keyphrases to extract
+		  -v, --verbose
+		  --help                          Show this message and exit.
 
 Python
 ************************

--- a/README.rst
+++ b/README.rst
@@ -54,19 +54,23 @@ Command line
 ************************
 How to use it on your favorite command line::
 
-	Usage: yake [OPTIONS]
 
-	Options:
-	-i, --input_file TEXT           Input file  [required]
-	-l, --language TEXT             Language
-	-n, --ngram-size INTEGER        Max size of the ngram.
-	-df, --dedup-func [leve|jaro|seqm]
-									Deduplication function.
-	-dl, --dedup-lim FLOAT          Deduplication limiar.
-	-ws, --window-size INTEGER      Window size.
-	-t, --top INTEGER               Number of keyphrases to extract
-	-v, --verbose
-	--help                          Show this message and exit
+```bash
+Usage: yake [OPTIONS]
+
+Options:
+  -ti, --text_input TEXT          Input text, SURROUNDED by single quotes(')
+  -i, --input_file TEXT           Input file
+  -l, --language TEXT             Language
+  -n, --ngram-size INTEGER        Max size of the ngram.
+  -df, --dedup-func [leve|jaro|seqm]
+                                  Deduplication function.
+  -dl, --dedup-lim FLOAT          Deduplication limiar.
+  -ws, --window-size INTEGER      Window size.
+  -t, --top INTEGER               Number of keyphrases to extract
+  -v, --verbose
+  --help                          Show this message and exit.
+```
 
 
 Python

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Command line
 How to use it on your favorite command line::
 
 
-```bash
+```shell
 Usage: yake [OPTIONS]
 
 Options:

--- a/yake/cli.py
+++ b/yake/cli.py
@@ -6,7 +6,8 @@ import click
 import yake
 
 @click.command()
-@click.option("-i",'--input_file', help='Input file', required=True)
+@click.option("-ti",'--text_input', help='Input text, SURROUNDED by single quotes(\')', required=False)
+@click.option("-i",'--input_file', help='Input file', required=False)
 @click.option("-l",'--language', default="en", help='Language', required=False)
 
 @click.option('-n','--ngram-size', default=3, help='Max size of the ngram.', required=False, type=int)
@@ -17,19 +18,32 @@ import yake
 @click.option('-t','--top', type=int,  help='Number of keyphrases to extract', default=10, required=False)
 @click.option('-v','--verbose', count=True, required=False)
 
-def keywords(input_file, language, ngram_size, verbose=False, dedup_func="seqm", dedup_lim=.9, window_size=1, top=10):
-	
-	with open(input_file) as fpath:
-		text_content = fpath.read()
+def keywords(text_input, input_file, language, ngram_size, verbose=False, dedup_func="seqm", dedup_lim=.9, window_size=1, top=10):
 
-		myake = yake.KeywordExtractor(lan=language,n=ngram_size, dedupLim=dedup_lim, dedupFunc=dedup_func, windowsSize=window_size, top=top)
+	def run_yake(text_content):
+		myake = yake.KeywordExtractor(lan=language, n=ngram_size, dedupLim=dedup_lim, dedupFunc=dedup_func,
+									  windowsSize=window_size, top=top)
 		results = myake.extract_keywords(text_content)
 
 		for kw in results:
-			if(verbose):
+			if (verbose):
 				print(kw[0], kw[1])
 			else:
 				print(kw[1])
+
+	if text_input and input_file:
+		print("You should specify either an input file or direct text input, but not both!")
+		exit(1)
+	elif not text_input and not input_file:
+			print("You should specify either an input file or direct text input")
+			exit(1)
+	else:
+		if text_input:
+			run_yake(text_input)
+		else:
+			with open(input_file) as fpath:
+				text_content = fpath.read()
+				run_yake(text_content)
 
 if __name__ == "__main__":
 	main()


### PR DESCRIPTION
**Added -ti command line option to allow direct input from the command line. (fix for #2)**

The CLI now requires **either** a input file path (-i argument) or a sentence from the command line (added -ti argument).

## Example:

```bash
(venv) ➜ yake git:(master) ✗ yake -ti 'Magistrados do Ministério Público marcam greve por temerem interferência dos políticos Paralisação começará em Fevereiro. Em causa está a intenção dos grupos parlamentares do PS e do PSD de mexer na composição do Conselho Superior do Ministério Público.'
políticos paralisação começará
ministério público marcam
dos políticos paralisação
público marcam greve
marcam greve por
greve por temerem
por temerem interferência
interferência dos políticos
temerem interferência dos
ministério público
```

## Input validation

```bash
(venv) ➜  yake git:(master) ✗ yake
You should specify either an input file or direct text input
```

## Updated usage message

```bash
(venv) ➜  yake git:(master) ✗ yake --help
Usage: yake [OPTIONS]

Options:
  -ti, --text_input TEXT          Input text, SURROUNDED by single quotes(')
  -i, --input_file TEXT           Input file
  -l, --language TEXT             Language
  -n, --ngram-size INTEGER        Max size of the ngram.
  -df, --dedup-func [leve|jaro|seqm]
                                  Deduplication function.
  -dl, --dedup-lim FLOAT          Deduplication limiar.
  -ws, --window-size INTEGER      Window size.
  -t, --top INTEGER               Number of keyphrases to extract
  -v, --verbose
  --help                          Show this message and exit.
````

## Reading from text file still works

```bash
(venv) ➜  yake git:(master) ✗ yake -i /Users/joaorocha/Desktop/teste.txt 
políticos paralisação começará
ministério público marcam
dos políticos paralisação
público marcam greve
marcam greve por
greve por temerem
por temerem interferência
interferência dos políticos
temerem interferência dos
ministério público
(venv) ➜  yake git:(master) ✗ 
```

