### PR TITLE
use utf-8 encoding when loading readme

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup, find_packages
 
-with open('README.md') as readme_file:
+with open('README.md', encoding='utf-8') as readme_file:
     readme = readme_file.read()
 
 requirements = [


### PR DESCRIPTION
When trying to install yake on python 3.6.8 directly from git I ran into the following error during setup:

> UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 9129: ordinal not in range(128)

The submitted PR prevents this by explicitly loading the readme using utf-8

Cheers and thanks for the awesome package!