### PR TITLE
Added handler for data that has no identified phrases

### DIFF
--- a/tests/test_yake.py
+++ b/tests/test_yake.py
@@ -71,4 +71,17 @@ def test_simple_interface():
     print(result)
 
     assert len(result) > 0
-    
+
+@pytest.mark.filterwarnings("error")
+def test_phraseless_example():
+    text_content = "- not yet"
+
+    pyake = yake.KeywordExtractor()
+
+    try:
+        result = pyake.extract_keywords(text_content)
+        assert len(result) == 0
+    except:
+        pytest.fail("Failed to handle small strings")
+
+

--- a/yake/datarepresentation.py
+++ b/yake/datarepresentation.py
@@ -103,6 +103,10 @@ class DataCore(object):
     def build_single_terms_features(self, features=None):
         validTerms = [ term for term in self.terms.values() if not term.stopword ]
         validTFs = (np.array([ x.tf for x in validTerms ]))
+
+        if len(validTFs) == 0:
+            return
+
         avgTF = validTFs.mean()
         stdTF = validTFs.std()
         maxTF = max([ x.tf for x in self.terms.values()])


### PR DESCRIPTION
I encountered issues when trying to extract phrases from small pieces of texts that didn't have any relevant key phrases.

I updates the unit tests to cover this. The test fails against the code in `master`, but the small change in this PR resolves it.