### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,10 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',    
     url='https://pypi.python.org/pypi/yake',
+    project_urls={
+        'Documentation': 'https://liaad.github.io/yake/',
+        'Source': 'https://github.com/LIAAD/yake',
+    },
     packages=find_packages(include=['yake','StopwordsList']),
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)